### PR TITLE
Fix outer declaration greediness

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const defaultImportObj = {
     global: '',
 };
 
-const BLANKLINES = /^\s*[\r\n]/gm;
+const BLANKLINES = /^\s*[\r\n]+/gm;
 const IMPORTS = /import\s+(.+from\s+)?'(.+).*';/gm;
 const DYNAMIC_IMPORTS = /import\(['"]([\w./-]+)['"]\)\.(\w+)/g;
 const REFERENCES = /\s*\/\/\/\s+<reference\s+.*\/>/gm;

--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@ const IMPORTS = /import\s+(.+from\s+)?'(.+).*';/gm;
 const DYNAMIC_IMPORTS = /import\(['"]([\w./-]+)['"]\)\.(\w+)/g;
 const REFERENCES = /\s*\/\/\/\s+<reference\s+.*\/>/gm;
 const DEFAULT_EXPORTS = /export\sdefault\s.*$/gm;
-const INNER_MODULE_DECLARATION = /}\ndeclare\smodule\s+.*{\n/g;
-const OUTER_MODULE_DECLARATION = /^declare\smodule\s.+{\s([\s\S]*)}/;
+const MODULE_DECLARATION = /^declare\smodule\s.+{\s([\s\S]*?)^}$/gm;
 const PRIVATES = /private .+;$/gm;
 const RELATIVE_PATH = /^\.?\.\/.+$/;
 const DESTRUCTURE_IMPORT = /(?:(?:(\*\sas\s\w+)|{\s(.+)\s})\sfrom\s)?'([\w./@-]+)'/;
@@ -43,8 +42,7 @@ module.exports = config =>
             .replace(REFERENCES, '')
             .replace(DEFAULT_EXPORTS, '')
             .replace(BLANKLINES, '')
-            .replace(INNER_MODULE_DECLARATION, '')
-            .replace(OUTER_MODULE_DECLARATION, (...regExpArgs) => getOuterModuleDeclaration(regExpArgs))
+            .replace(MODULE_DECLARATION, (...regExpArgs) => getOuterModuleDeclaration(regExpArgs))
             .replace(EMPTY_BRACES, '{}')
             .replace(BLANKLINES, '');
 


### PR DESCRIPTION
Changed the regex used to properly detect modules, thus removing the concept of "INNER" and "OUTER" modules:

`/^declare\smodule\s.+{\s([\s\S]*?)^}$/gm;` =>

* `^declare\smodule \s.+{` matches the start of a line with "declare module" until it's bracket.
* `\s([\s\S]*?)` matches the content of this module, lazily just to ensure that it does not capture all `}` of the file.
* `^}$` the match ends when a `}` character is found alone on a single line. 

----

Fixes the module on Windows since the original `INNER_MODULE_DECLARATION` did not match Windows' EOL characters `\r\n` which misproduced the cleaned up declaration file.

I have compared the result of this fix with an original file built with `eol: '\n'` and it gives the same end result.